### PR TITLE
Update environments to Dask 2.23.0

### DIFF
--- a/hyper-parameter-optimmization/environment.yml
+++ b/hyper-parameter-optimmization/environment.yml
@@ -1,14 +1,12 @@
-name: pytorch
 channels:
   - conda-forge
   - pytorch
   - defaults
 dependencies:
   - python=3.7
-  - dask
+  - dask>=2.23.0
   - numpy
-  - pandas
-  - coiled
+  - pandas>=1.1.0
   - dask-ml
   - skorch
   - scipy

--- a/pangeo/environment.yml
+++ b/pangeo/environment.yml
@@ -1,11 +1,9 @@
-name: pangeo
 channels:
   - conda-forge
 dependencies:
   - python=3.7
-  - coiled
   - sat-search
-  - dask
+  - dask>=2.23.0
   - numpy
   - xarray
   - geopandas

--- a/scaling-xgboost/environment.yml
+++ b/scaling-xgboost/environment.yml
@@ -1,11 +1,9 @@
-name: xgboost
 channels:
   - conda-forge
 dependencies:
   - python=3.8
-  - dask=2.21.0
-  - pandas=1.0.5
-  - coiled
+  - dask>=2.23.0
+  - pandas>=1.1.0
   - xgboost
   - dask-ml
   - dask-xgboost


### PR DESCRIPTION
This accounts for a recent change to `distributed` (xref https://github.com/dask/distributed/pull/4019). I've confirmed that all the examples run successfully in their new software environments 